### PR TITLE
bug fix: golang:alpine fails to download additional packages above 3.12

### DIFF
--- a/fcbuild.Dockerfile
+++ b/fcbuild.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS build
+FROM golang:alpine3.12 AS build
 
 RUN apk add \
     build-base \


### PR DESCRIPTION
Use fixed Alpine base version (3.12) when building in Docker.